### PR TITLE
Support path component in server address

### DIFF
--- a/lib/Pages/settings_page/subwidgets/server_settings.dart
+++ b/lib/Pages/settings_page/subwidgets/server_settings.dart
@@ -211,7 +211,7 @@ class _ServerSettingsState extends State<ServerSettings> {
       );
     }
 
-    final String formattedAddress = "${url.scheme}://${url.host}${url.hasPort ? ":${url.port}" : ""}/${url.path}";
+    final String formattedAddress = "${url.scheme}://${url.host}${url.hasPort ? ":${url.port}" : ""}${url.path}";
     return formattedAddress;
   }
 

--- a/lib/Pages/settings_page/subwidgets/server_settings.dart
+++ b/lib/Pages/settings_page/subwidgets/server_settings.dart
@@ -211,12 +211,7 @@ class _ServerSettingsState extends State<ServerSettings> {
       );
     }
 
-    String formattedAddress = "${url.scheme}://${url.host}";
-
-    if (url.hasPort) {
-      formattedAddress += ":${url.port}";
-    }
-
+    final String formattedAddress = "${url.scheme}://${url.host}${url.hasPort ? ":${url.port}" : ""}/${url.path}";
     return formattedAddress;
   }
 


### PR DESCRIPTION
Hi! I host an Ollama installation proxied behind a subpath of my domain (e.g. https://example.com/ollama). The Ollama client supports subpaths automatically, but it looks like Reins currently strips the subpath due to how it generates the final, formatted address.

This PR simply restores the `url.path` component to the generated address so that it is preserved!