### PR TITLE
FR - support attachments of PDF and Markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,45 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# iOS/macOS
+**/ios/Pods/
+**/ios/.symlinks/
+**/ios/Flutter/Flutter.framework
+**/ios/Flutter/Flutter.podspec
+**/macos/Pods/
+**/macos/.symlinks/
+**/macos/Flutter/ephemeral/
+**/macos/Flutter/Flutter-Debug.xcconfig
+**/macos/Flutter/Flutter-Release.xcconfig
+**/macos/Flutter/Flutter-Profile.xcconfig
+
+# Windows
+**/windows/flutter/ephemeral/
+
+# Linux
+**/linux/flutter/ephemeral/
+
+# Coverage
+coverage/
+*.lcov
+
+# Test related
+.test_coverage.dart
+
+# Generated files
+*.g.dart
+*.freezed.dart
+*.mocks.dart
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# IDE
+.vscode/
+*.code-workspace
+
+# Documentation builds
+doc/api/

--- a/lib/Models/ollama_message.dart
+++ b/lib/Models/ollama_message.dart
@@ -15,6 +15,9 @@ class OllamaMessage {
   /// The image content of the message.
   List<File>? images;
 
+  /// The document content of the message.
+  List<File>? documents;
+
   /// The date and time the message was created.
   DateTime createdAt;
 
@@ -40,6 +43,7 @@ class OllamaMessage {
     String? id,
     required this.role,
     this.images,
+    this.documents,
     DateTime? createdAt,
     this.model,
     this.done,
@@ -83,7 +87,8 @@ class OllamaMessage {
       map['content'],
       id: map['message_id'],
       role: OllamaMessageRole.fromString(map['role']),
-      images: _constructImages(map['images']),
+      images: _constructFiles(map['images']),
+      documents: _constructFiles(map['documents']),
       createdAt: DateTime.fromMillisecondsSinceEpoch(map['timestamp']),
       model: map['model'],
     );
@@ -118,7 +123,8 @@ class OllamaMessage {
   Map<String, dynamic> toDatabaseMap() => {
         'message_id': id,
         'content': content,
-        'images': _breakImages(images),
+        'images': _breakFiles(images),
+        'documents': _breakFiles(documents),
         'role': role.toCaseString(),
         'timestamp': createdAt.millisecondsSinceEpoch,
       };
@@ -145,13 +151,13 @@ class OllamaMessage {
     return null;
   }
 
-  static List<File>? _constructImages(String? raw) {
+  static List<File>? _constructFiles(String? raw) {
     if (raw != null) {
       final List<dynamic> decoded = jsonDecode(raw);
-      return decoded.map((imageRelativePath) {
+      return decoded.map((fileRelativePath) {
         return File(path.join(
           PathManager.instance.documentsDirectory.path,
-          imageRelativePath,
+          fileRelativePath,
         ));
       }).toList();
     }
@@ -159,16 +165,16 @@ class OllamaMessage {
     return null;
   }
 
-  String? _breakImages(List<File>? images) {
-    if (images != null) {
-      final relativePathImages = images.map((file) {
+  String? _breakFiles(List<File>? files) {
+    if (files != null) {
+      final relativePathFiles = files.map((file) {
         return path.relative(
           file.path,
           from: PathManager.instance.documentsDirectory.path,
         );
       }).toList();
 
-      return jsonEncode(relativePathImages);
+      return jsonEncode(relativePathFiles);
     }
 
     return null;

--- a/lib/Pages/chat_page/chat_page_view_model.dart
+++ b/lib/Pages/chat_page/chat_page_view_model.dart
@@ -9,16 +9,19 @@ class ChatPageViewModel {
   final DatabaseService _databaseService;
   final PermissionService _permissionService;
   final ImageService _imageService;
+  final FileService _fileService;
 
   ChatPageViewModel({
     required OllamaService ollamaService,
     required DatabaseService databaseService,
     required PermissionService permissionService,
     required ImageService imageService,
+    required FileService fileService,
   })  : _ollamaService = ollamaService,
         _databaseService = databaseService,
         _permissionService = permissionService,
-        _imageService = imageService;
+        _imageService = imageService,
+        _fileService = fileService;
 
   /// Handles image picking and compression
   Future<List<File>> pickImages({
@@ -58,5 +61,20 @@ class ChatPageViewModel {
   /// Deletes multiple images
   Future<void> deleteImages(List<File> imageFiles) async {
     await _imageService.deleteImages(imageFiles);
+  }
+
+  /// Handles document picking
+  Future<List<File>> pickDocuments() async {
+    return await _fileService.pickDocuments();
+  }
+
+  /// Deletes a single document
+  Future<void> deleteDocument(File documentFile) async {
+    await _fileService.deleteDocument(documentFile);
+  }
+
+  /// Deletes multiple documents
+  Future<void> deleteDocuments(List<File> documentFiles) async {
+    await _fileService.deleteDocuments(documentFiles);
   }
 }

--- a/lib/Pages/chat_page/subwidgets/chat_attachment/chat_attachment_document.dart
+++ b/lib/Pages/chat_page/subwidgets/chat_attachment/chat_attachment_document.dart
@@ -1,0 +1,67 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:path/path.dart' as path;
+import 'package:reins/Services/services.dart';
+
+class ChatAttachmentDocument extends StatelessWidget {
+  final File documentFile;
+  final Function(File) onRemove;
+
+  const ChatAttachmentDocument({
+    super.key,
+    required this.documentFile,
+    required this.onRemove,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final fileName = path.basename(documentFile.path);
+    final fileService = FileService();
+    final icon = fileService.getFileTypeIcon(documentFile);
+
+    return Container(
+      width: 120,
+      height: MediaQuery.of(context).size.height * 0.15,
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Stack(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  icon,
+                  style: const TextStyle(fontSize: 32),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  fileName,
+                  style: Theme.of(context).textTheme.bodySmall,
+                  textAlign: TextAlign.center,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ),
+          ),
+          Positioned(
+            top: 2,
+            right: 2,
+            child: InkWell(
+              onTap: () => onRemove(documentFile),
+              child: Icon(
+                Icons.close,
+                color: Theme.of(context).colorScheme.onSurface,
+                size: 20,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/Pages/chat_page/subwidgets/subwidgets.dart
+++ b/lib/Pages/chat_page/subwidgets/subwidgets.dart
@@ -7,4 +7,5 @@ export 'chat_error.dart';
 
 export 'chat_attachment/chat_attachment_row.dart';
 export 'chat_attachment/chat_attachment_image.dart';
+export 'chat_attachment/chat_attachment_document.dart';
 export 'chat_attachment/chat_attachment_preset.dart';

--- a/lib/Services/file_service.dart
+++ b/lib/Services/file_service.dart
@@ -1,0 +1,96 @@
+import 'dart:io';
+import 'package:file_picker/file_picker.dart';
+import 'package:path/path.dart' as path;
+import 'package:syncfusion_flutter_pdf/pdf.dart';
+import 'package:reins/Constants/constants.dart';
+
+class FileService {
+  static const int maxFileSizeBytes = 10 * 1024 * 1024; // 10MB
+  static const List<String> supportedExtensions = ['pdf', 'md', 'markdown', 'txt'];
+
+  Future<Directory> getDocumentsDirectory() async {
+    final documentsDirectory = PathManager.instance.documentsDirectory;
+    final documentsPath = path.join(documentsDirectory.path, 'documents');
+    return await Directory(documentsPath).create(recursive: true);
+  }
+
+  Future<List<File>> pickDocuments() async {
+    try {
+      final result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: supportedExtensions,
+        allowMultiple: false,
+      );
+
+      if (result == null || result.files.isEmpty) return [];
+
+      final pickedFile = result.files.first;
+      if (pickedFile.path == null) return [];
+
+      final file = File(pickedFile.path!);
+      
+      // Validate file size
+      final fileSize = await file.length();
+      if (fileSize > maxFileSizeBytes) return [];
+
+      // Copy to app documents directory
+      final documentsDir = await getDocumentsDirectory();
+      final fileName = '${DateTime.now().microsecondsSinceEpoch}_${pickedFile.name}';
+      final targetPath = path.join(documentsDir.path, fileName);
+      final copiedFile = await file.copy(targetPath);
+
+      return [copiedFile];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  Future<String?> extractTextContent(File file) async {
+    try {
+      final extension = path.extension(file.path).toLowerCase();
+      
+      switch (extension) {
+        case '.pdf':
+          final bytes = await file.readAsBytes();
+          final document = PdfDocument(inputBytes: bytes);
+          final textExtractor = PdfTextExtractor(document);
+          final text = textExtractor.extractText();
+          document.dispose();
+          return text;
+        case '.md':
+        case '.markdown':
+        case '.txt':
+          return await file.readAsString();
+        default:
+          return null;
+      }
+    } catch (e) {
+      return null;
+    }
+  }
+
+  Future<void> deleteDocument(File documentFile) async {
+    if (await documentFile.exists()) {
+      await documentFile.delete();
+    }
+  }
+
+  Future<void> deleteDocuments(List<File> documentFiles) async {
+    await Future.wait(documentFiles.map((file) => deleteDocument(file)));
+  }
+
+  String getFileTypeIcon(File file) {
+    final extension = path.extension(file.path).toLowerCase();
+    switch (extension) {
+      case '.pdf':
+        return '📄';
+      case '.md':
+      case '.markdown':
+        return '📝';
+      case '.txt':
+        return '📄';
+      default:
+        return '📎';
+    }
+  }
+}

--- a/lib/Services/services.dart
+++ b/lib/Services/services.dart
@@ -1,4 +1,5 @@
 export 'database_service.dart';
+export 'file_service.dart';
 export 'ollama_service.dart';
 export 'permission_service.dart';
 export 'image_service.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,10 +54,12 @@ void main() async {
         Provider(create: (_) => DatabaseService()),
         Provider(create: (_) => PermissionService()),
         Provider(create: (_) => ImageService()),
+        Provider(create: (_) => FileService()),
         ChangeNotifierProvider(
           create: (context) => ChatProvider(
             ollamaService: context.read(),
             databaseService: context.read(),
+            fileService: context.read(),
           ),
         ),
         Provider(
@@ -66,6 +68,7 @@ void main() async {
             databaseService: context.read(),
             permissionService: context.read(),
             imageService: context.read(),
+            fileService: context.read(),
           ),
         ),
       ],

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import file_picker
 import file_selector_macos
 import flutter_image_compress_macos
 import in_app_review
@@ -14,6 +15,7 @@ import sqflite_darwin
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterImageCompressMacosPlugin.register(with: registry.registrar(forPlugin: "FlutterImageCompressMacosPlugin"))
   InAppReviewPlugin.register(with: registry.registrar(forPlugin: "InAppReviewPlugin"))

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -28,8 +28,8 @@
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
 		71F7DA8F04247AE1D19A2DCD /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 841B3B8083C57E19AD9E9A39 /* Pods_Runner.framework */; };
-		9785DAF82BC9CBFE9E6331D8 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 40313F7815DB5898F649E72C /* Pods_RunnerTests.framework */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
+		9785DAF82BC9CBFE9E6331D8 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 40313F7815DB5898F649E72C /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -84,12 +84,12 @@
 		40313F7815DB5898F649E72C /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6BA878D82D9B7B2488681BB9 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		6C75AEA4E1BCA2C4E7D8E1F6 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		841B3B8083C57E19AD9E9A39 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		D9E98E29FD205FB645BE4B3A /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		F523C65FA81D55D22704E750 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
-		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -234,9 +234,6 @@
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		33CC10EC2044A3C60003C045 /* Runner */ = {
-			packageProductDependencies = (
-				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
-			);
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
@@ -254,6 +251,9 @@
 				33CC11202044C79F0003C045 /* PBXTargetDependency */,
 			);
 			name = Runner;
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			productName = Runner;
 			productReference = 33CC10ED2044A3C60003C045 /* Reins.app */;
 			productType = "com.apple.product-type.application";
@@ -262,9 +262,6 @@
 
 /* Begin PBXProject section */
 		33CC10E52044A3C60003C045 /* Project object */ = {
-			packageReferences = (
-				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
-			);
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
@@ -279,7 +276,6 @@
 					33CC10EC2044A3C60003C045 = {
 						CreatedOnToolsVersion = 9.2;
 						LastSwiftMigration = 1100;
-						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.Sandbox = {
 								enabled = 1;
@@ -301,6 +297,9 @@
 				Base,
 			);
 			mainGroup = 33CC10E42044A3C60003C045;
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
+			);
 			productRefGroup = 33CC10EE2044A3C60003C045 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -584,7 +583,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 9HQV48CK77;
+				DEVELOPMENT_TEAM = K3B5FSPCG5;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Reins;
@@ -720,10 +719,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 9HQV48CK77;
+				DEVELOPMENT_TEAM = K3B5FSPCG5;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Reins;
@@ -751,8 +751,19 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 9HQV48CK77;
+				DEVELOPMENT_TEAM = K3B5FSPCG5;
+				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = NO;
+				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
+				ENABLE_RESOURCE_ACCESS_BLUETOOTH = NO;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
+				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
+				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
+				ENABLE_RESOURCE_ACCESS_USB = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Reins;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
@@ -827,12 +838,14 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
 /* Begin XCLocalSwiftPackageReference section */
-		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
 		};
 /* End XCLocalSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -76,6 +76,10 @@ dependencies:
   photo_view: ^0.15.0
   permission_handler: ^11.3.1
 
+  # File support
+  file_picker: ^8.1.2
+  syncfusion_flutter_pdf: ^27.1.58
+
   # In-app review
   in_app_review: ^2.0.10
 

--- a/test/file_service_test.dart
+++ b/test/file_service_test.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reins/Services/file_service.dart';
+
+void main() {
+  group('FileService', () {
+    late FileService fileService;
+
+    setUp(() {
+      fileService = FileService();
+    });
+
+    test('should return correct file type icons', () {
+      expect(fileService.getFileTypeIcon(File('test.pdf')), '📄');
+      expect(fileService.getFileTypeIcon(File('test.md')), '📝');
+      expect(fileService.getFileTypeIcon(File('test.markdown')), '📝');
+      expect(fileService.getFileTypeIcon(File('test.txt')), '📄');
+      expect(fileService.getFileTypeIcon(File('test.unknown')), '📎');
+    });
+
+    test('should validate supported extensions', () {
+      expect(FileService.supportedExtensions, contains('pdf'));
+      expect(FileService.supportedExtensions, contains('md'));
+      expect(FileService.supportedExtensions, contains('markdown'));
+      expect(FileService.supportedExtensions, contains('txt'));
+    });
+
+    test('should have reasonable file size limit', () {
+      expect(FileService.maxFileSizeBytes, equals(10 * 1024 * 1024)); // 10MB
+    });
+  });
+}


### PR DESCRIPTION
Added support for attaching PDF and Markdown files to chat conversations, with automatic text extraction and content integration into prompts.

# Feature: PDF and Markdown Document Support

## Summary
Added support for attaching PDF and Markdown files to chat conversations, with automatic text extraction and content integration into prompts.

## Motivation
Users needed the ability to share document content with their LLMs beyond just images. This feature enables document-based conversations, allowing users to ask questions about PDFs, analyze markdown files, and work with text documents directly in their chats.

## Changes

### New Features
- **Document Attachment**: Users can now attach PDF, Markdown (.md, .markdown), and text files to messages
- **Automatic Text Extraction**: Content is automatically extracted from documents and included in the chat context
- **File Type Support**: PDF, Markdown, and plain text files up to 10MB
- **Mixed Attachments**: Support for both images and documents in the same message
- **Visual Indicators**: Document attachments display with appropriate file type icons (📄 for PDF, 📝 for Markdown)

### Technical Implementation
- Added `file_picker` and `syncfusion_flutter_pdf` dependencies
- Created `FileService` for document handling and text extraction
- Extended `OllamaMessage` model with `documents` field
- Updated database schema (v2) with migration support for existing installations
- Enhanced UI with document attachment widget and selection dialog
- Integrated document content processing into chat provider

### User Experience
1. Tap the attachment button (+) in chat
2. Select "Document" from the options menu
3. Choose a PDF or Markdown file from device storage
4. Document appears as an attachment with file name and icon
5. Send message - document content is automatically extracted and included in the prompt
6. LLM receives both the user's text and the document content

### Files Changed
**New:**
- `lib/Services/file_service.dart`
- `lib/Pages/chat_page/subwidgets/chat_attachment/chat_attachment_document.dart`
- `test/file_service_test.dart`

**Modified:**
- `pubspec.yaml` - Dependencies
- `lib/Models/ollama_message.dart` - Document field
- `lib/Providers/chat_provider.dart` - Content processing
- `lib/Pages/chat_page/chat_page.dart` - UI enhancements
- `lib/Services/database_service.dart` - Schema migration
- `lib/main.dart` - Provider setup

### Backward Compatibility
- Database migration ensures existing installations upgrade seamlessly
- Existing chats and messages remain unaffected
- No breaking changes to existing functionality

### Limitations
- Maximum file size: 10MB
- Supported formats: PDF, Markdown (.md, .markdown), plain text (.txt)
- Single document per message (can be extended in future)

## Testing
- Tested on iOS, Android, macOS, Linux, and Windows
- Verified database migration from v1 to v2
- Confirmed text extraction from various PDF and Markdown files
- Validated file size limits and error handling

## Future Enhancements
- Support for multiple documents per message
- Additional file formats (DOCX, RTF, etc.)
- Document preview/viewer
- File compression for large documents
- Cloud storage integration




Fixes https://github.com/ibrahimcetin/reins/issues/30